### PR TITLE
fixed build script to match the libbpf name that BCC uses: libbcc_bpf.so

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 # Note the generated opensnoop executable must be run with sudo.
 set -e
 python opensnoop.py
-clang opensnoop.c -lelf -O3 -o opensnoop /usr/lib/x86_64-linux-gnu/libbpf.so
+clang opensnoop.c -lelf -O3 -o opensnoop /usr/lib/x86_64-linux-gnu/libbcc_bpf.so

--- a/generated_bytecode.h
+++ b/generated_bytecode.h
@@ -129,15 +129,15 @@ void generate_trace_entry(struct bpf_insn instructions[], int infotmp_fd) {
   instructions[16] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_7,
-      .off     = -8,
+      .src_reg = BPF_REG_6,
+      .off     = -32,
       .imm     = 0,
   };
   instructions[17] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_6,
-      .off     = -32,
+      .src_reg = BPF_REG_7,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[18] = (struct bpf_insn) {
@@ -391,15 +391,15 @@ void generate_trace_entry_progeny(struct bpf_insn instructions[], int infotmp_fd
   instructions[25] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_7,
-      .off     = -8,
+      .src_reg = BPF_REG_6,
+      .off     = -32,
       .imm     = 0,
   };
   instructions[26] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_6,
-      .off     = -32,
+      .src_reg = BPF_REG_7,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[27] = (struct bpf_insn) {
@@ -493,7 +493,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .code    = 0x63,
       .dst_reg = BPF_REG_10,
       .src_reg = BPF_REG_1,
-      .off     = -4,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[3] = (struct bpf_insn) {
@@ -571,7 +571,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .dst_reg = BPF_REG_1,
       .src_reg = BPF_REG_0,
       .off     = 0,
-      .imm     = -4,
+      .imm     = -8,
   };
   instructions[14] = (struct bpf_insn) {
       .code    = 0xb7,
@@ -591,14 +591,14 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .code    = 0x61,
       .dst_reg = BPF_REG_1,
       .src_reg = BPF_REG_10,
-      .off     = -4,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[17] = (struct bpf_insn) {
       .code    = 0x63,
       .dst_reg = BPF_REG_10,
       .src_reg = BPF_REG_1,
-      .off     = -16,
+      .off     = -4,
       .imm     = 0,
   };
   instructions[18] = (struct bpf_insn) {
@@ -627,7 +627,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .dst_reg = BPF_REG_2,
       .src_reg = BPF_REG_0,
       .off     = 0,
-      .imm     = -16,
+      .imm     = -4,
   };
   instructions[22] = (struct bpf_insn) {
       .code    = 0x85,
@@ -661,7 +661,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .code    = 0x63,
       .dst_reg = BPF_REG_10,
       .src_reg = BPF_REG_0,
-      .off     = -4,
+      .off     = -16,
       .imm     = 0,
   };
   instructions[27] = (struct bpf_insn) {
@@ -675,7 +675,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .code    = 0x63,
       .dst_reg = BPF_REG_10,
       .src_reg = BPF_REG_1,
-      .off     = -20,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[29] = (struct bpf_insn) {
@@ -704,7 +704,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .dst_reg = BPF_REG_2,
       .src_reg = BPF_REG_0,
       .off     = 0,
-      .imm     = -4,
+      .imm     = -16,
   };
   instructions[33] = (struct bpf_insn) {
       .code    = 0xbf,
@@ -718,7 +718,7 @@ void generate_execve_entry(struct bpf_insn instructions[], int progeny_pids_fd) 
       .dst_reg = BPF_REG_3,
       .src_reg = BPF_REG_0,
       .off     = 0,
-      .imm     = -20,
+      .imm     = -8,
   };
   instructions[35] = (struct bpf_insn) {
       .code    = 0xb7,
@@ -967,15 +967,15 @@ void generate_trace_entry_tid(struct bpf_insn instructions[], int tid, int infot
   instructions[20] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_7,
-      .off     = -8,
+      .src_reg = BPF_REG_6,
+      .off     = -32,
       .imm     = 0,
   };
   instructions[21] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_6,
-      .off     = -32,
+      .src_reg = BPF_REG_7,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[22] = (struct bpf_insn) {
@@ -1215,15 +1215,15 @@ void generate_trace_entry_pid(struct bpf_insn instructions[], int pid, int infot
   instructions[23] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_7,
-      .off     = -8,
+      .src_reg = BPF_REG_6,
+      .off     = -32,
       .imm     = 0,
   };
   instructions[24] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_6,
-      .off     = -32,
+      .src_reg = BPF_REG_7,
+      .off     = -8,
       .imm     = 0,
   };
   instructions[25] = (struct bpf_insn) {
@@ -1736,15 +1736,15 @@ void generate_trace_return(struct bpf_insn instructions[], int infotmp_fd, int e
   instructions[62] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_7,
-      .off     = -296,
+      .src_reg = BPF_REG_1,
+      .off     = -304,
       .imm     = 0,
   };
   instructions[63] = (struct bpf_insn) {
       .code    = 0x7b,
       .dst_reg = BPF_REG_10,
-      .src_reg = BPF_REG_1,
-      .off     = -304,
+      .src_reg = BPF_REG_7,
+      .off     = -296,
       .imm     = 0,
   };
   instructions[64] = (struct bpf_insn) {

--- a/rust/opensnoop/src/generated_bytecode.rs
+++ b/rust/opensnoop/src/generated_bytecode.rs
@@ -112,14 +112,14 @@ pub fn generate_trace_entry(instructions: &mut [libbpf::bpf_insn], infotmp_fd: &
   };
   instructions[16] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
-      off: -8,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
+      off: -32,
       imm: 0,
   };
   instructions[17] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
-      off: -32,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
+      off: -8,
       imm: 0,
   };
   instructions[18] = libbpf::bpf_insn {
@@ -337,14 +337,14 @@ pub fn generate_trace_entry_progeny(instructions: &mut [libbpf::bpf_insn], infot
   };
   instructions[25] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
-      off: -8,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
+      off: -32,
       imm: 0,
   };
   instructions[26] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
-      off: -32,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
+      off: -8,
       imm: 0,
   };
   instructions[27] = libbpf::bpf_insn {
@@ -425,7 +425,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
   instructions[2] = libbpf::bpf_insn {
       code: 0x63,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 1),
-      off: -4,
+      off: -8,
       imm: 0,
   };
   instructions[3] = libbpf::bpf_insn {
@@ -492,7 +492,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
       code: 0x7,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(1, 0),
       off: 0,
-      imm: -4,
+      imm: -8,
   };
   instructions[14] = libbpf::bpf_insn {
       code: 0xb7,
@@ -509,13 +509,13 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
   instructions[16] = libbpf::bpf_insn {
       code: 0x61,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(1, 10),
-      off: -4,
+      off: -8,
       imm: 0,
   };
   instructions[17] = libbpf::bpf_insn {
       code: 0x63,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 1),
-      off: -16,
+      off: -4,
       imm: 0,
   };
   instructions[18] = libbpf::bpf_insn {
@@ -540,7 +540,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
       code: 0x7,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(2, 0),
       off: 0,
-      imm: -16,
+      imm: -4,
   };
   instructions[22] = libbpf::bpf_insn {
       code: 0x85,
@@ -569,7 +569,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
   instructions[26] = libbpf::bpf_insn {
       code: 0x63,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 0),
-      off: -4,
+      off: -16,
       imm: 0,
   };
   instructions[27] = libbpf::bpf_insn {
@@ -581,7 +581,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
   instructions[28] = libbpf::bpf_insn {
       code: 0x63,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 1),
-      off: -20,
+      off: -8,
       imm: 0,
   };
   instructions[29] = libbpf::bpf_insn {
@@ -606,7 +606,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
       code: 0x7,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(2, 0),
       off: 0,
-      imm: -4,
+      imm: -16,
   };
   instructions[33] = libbpf::bpf_insn {
       code: 0xbf,
@@ -618,7 +618,7 @@ pub fn generate_execve_entry(instructions: &mut [libbpf::bpf_insn], progeny_pids
       code: 0x7,
       _bitfield_1: libbpf::bpf_insn::new_bitfield_1(3, 0),
       off: 0,
-      imm: -20,
+      imm: -8,
   };
   instructions[35] = libbpf::bpf_insn {
       code: 0xb7,
@@ -832,14 +832,14 @@ pub fn generate_trace_entry_tid(instructions: &mut [libbpf::bpf_insn], tid: i32,
   };
   instructions[20] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
-      off: -8,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
+      off: -32,
       imm: 0,
   };
   instructions[21] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
-      off: -32,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
+      off: -8,
       imm: 0,
   };
   instructions[22] = libbpf::bpf_insn {
@@ -1045,14 +1045,14 @@ pub fn generate_trace_entry_pid(instructions: &mut [libbpf::bpf_insn], pid: i32,
   };
   instructions[23] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
-      off: -8,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
+      off: -32,
       imm: 0,
   };
   instructions[24] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 6),
-      off: -32,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
+      off: -8,
       imm: 0,
   };
   instructions[25] = libbpf::bpf_insn {
@@ -1492,14 +1492,14 @@ pub fn generate_trace_return(instructions: &mut [libbpf::bpf_insn], infotmp_fd: 
   };
   instructions[62] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
-      off: -296,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 1),
+      off: -304,
       imm: 0,
   };
   instructions[63] = libbpf::bpf_insn {
       code: 0x7b,
-      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 1),
-      off: -304,
+      _bitfield_1: libbpf::bpf_insn::new_bitfield_1(10, 7),
+      off: -296,
       imm: 0,
   };
   instructions[64] = libbpf::bpf_insn {


### PR DESCRIPTION
Tested on Ubuntu 18.04/Linux 4.15.0 with latest BCC installed.
Ran commands:

```
git clone https://github.com/bolinfest/opensnoop-native.git
./build.sh

# output
clang: error: no such file or directory: '/usr/lib/x86_64-linux-gnu/libbpf.so'
```
There's a libbpf.so file in /lib/x86_64-linux-gnu/, so I tried linking that first (like an idiot). Didn't work because BCC has their own BPF functions that are helpful. Looked for libbpf.so in the intended location and found a file named libbcc_bpf.so. 
Changed the name in build.sh, and now it compiles and runs.

Have you done any looking into how this might be run without the BCC libraries? I'm trying to understand how to just use the kernel headers and libraries. Or, at least, be able to run a C program with just a few files that it depends on rather than having to install the entire BCC ecosystem.

The article and the repo are amazing! Even two years later it's one of the best resources on working with low-level BPF that I've been able to find.

